### PR TITLE
added folder for README

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ Email : ${email}`;
 
 // the aforementioned function, now fleshed out
 function createNewFile(data) {
-    fs.writeFile(`./README.md`, data, (err) => {
+    fs.writeFile(`./doc/README.md`, data, (err) => {
         if (err) {
             console.log(err)
         }


### PR DESCRIPTION
Discovered an issue where creating multiple READMEs would just overwrite the same file. By creating a folder for the file and subsequently pulling it out, this issue was solved